### PR TITLE
Implement action dispatcher

### DIFF
--- a/app/plugins/zen/threes/src/js/auto-register-mixin.js
+++ b/app/plugins/zen/threes/src/js/auto-register-mixin.js
@@ -1,0 +1,12 @@
+export default {
+    mounted() {
+        if (this.$options.name) {
+            ths.data.components[this.$options.name] = this
+        }
+    },
+    unmounted() {
+        if (this.$options.name && ths.data.components[this.$options.name] === this) {
+            delete ths.data.components[this.$options.name]
+        }
+    }
+}

--- a/app/plugins/zen/threes/src/js/threes.js
+++ b/app/plugins/zen/threes/src/js/threes.js
@@ -19,12 +19,16 @@ window.ths = {
 
     /* Объект для хранения глобальных данных */
     data: reactive({
+        components: {},
         ui_streams: [],
         process: false,
         node_selected_nid: null, // string | null - nid выбранного нода
         node_actions_nid: null, // string | null - nid нода для которого открыты настройки actions
         node_action: null, // string ex: 'move', 'copy', 'link', 'delete' - Выбранный action
     }),
+
+    queue: [],
+    loopStarted: false,
 
     api(opts) {
         let domain = location.origin
@@ -57,29 +61,20 @@ window.ths = {
             }
         }
 
-        if (!data) {
-            axios.get(api_url, axios_options)
-                .then((response) => {
-                    console.log('Threes response [' + request_key + ']', response.data) // todo:debug
-                    this.afterResponse(response.data, opts.then, request_key)
-                })
-                .catch((error) => {
-                    delete this.requests_register[request_key]
-                    this.preloader(false)
-                    console.log(error) // todo:debug
-                })
-        } else {
-            axios.post(api_url, data, axios_options)
-                .then((response) => {
-                    console.log('Threes response [' + request_key + ']', response.data) // todo:debug
-                    this.afterResponse(response.data, opts.then, request_key)
-                })
-                .catch((error) => {
-                    delete this.requests_register[request_key]
-                    this.preloader(false)
-                    console.log(error) // todo:debug
-                })
-        }
+        const request = !data
+            ? axios.get(api_url, axios_options)
+            : axios.post(api_url, data, axios_options)
+
+        return request
+            .then((response) => {
+                console.log('Threes response [' + request_key + ']', response.data)
+                return this.afterResponse(response.data, request_key)
+            })
+            .catch((error) => {
+                delete this.requests_register[request_key]
+                this.preloader(false)
+                console.log(error)
+            })
     },
 
     // Показать 1 сообщение
@@ -100,27 +95,97 @@ window.ths = {
     },
 
     // Постобработка данных
-    afterResponse(response, then, request_key) {
+    afterResponse(response, request_key) {
         delete this.requests_register[request_key]
         this.preloader(false)
         if (response.messages) {
             this.pushMessages(response.messages)
         }
 
-        // Если ответ с подтверждением, прерываем обработку
         if (response.confirm) {
             if (this.Submit !== null) {
-                this.Submit.push(response, then)
+                this.Submit.push(response)
             }
-            return
+            return null
         }
-
-        if (then) {
-            then(response)
-        }
+        return response
     },
     preloader(state) {
         this.data.process = state
+    },
+
+    exec(path, ...args) {
+        if (!path) {
+            return
+        }
+        const [compName, methodName] = path.split('.')
+        const comp = this.data.components[compName]
+        if (comp && typeof comp[methodName] === 'function') {
+            return comp[methodName](...args)
+        }
+        console.warn('ths.exec: component or method not found', path)
+    },
+
+    processThen(then, result) {
+        if (!then) {
+            return
+        }
+        const call = (t, res) => {
+            if (typeof t === 'string') {
+                return this.exec(t, res)
+            }
+            if (typeof t === 'function') {
+                return t(res)
+            }
+        }
+        if (Array.isArray(then)) {
+            return then.reduce((res, t) => call(t, res), result)
+        }
+        return call(then, result)
+    },
+
+    executeAction(action) {
+        let execResult;
+        if (typeof action.exec === 'string') {
+            execResult = this.exec(action.exec, action.data);
+        } else if (typeof action.exec === 'function') {
+            execResult = action.exec(action.data);
+        }
+        Promise.resolve(execResult).then(result => this.processThen(action.then, result));
+    },
+
+    tryFlushQueue() {
+        if (!this.loopStarted) {
+            this.flushLoop()
+        }
+    },
+
+    enqueue(action) {
+        this.tryFlushQueue()
+        action.hash = action.hash || md5(JSON.stringify(action.data || {}))
+        if (!this.queue.find(a => a.hash === action.hash)) {
+            action.delay = action.delay || 0
+            this.queue.push(action)
+        }
+    },
+
+    flushLoop() {
+        if (this.loopStarted) {
+            return
+        }
+        this.loopStarted = true
+        setInterval(() => {
+            for (let i = 0; i < this.queue.length; i++) {
+                const action = this.queue[i]
+                if (action.delay > 0) {
+                    action.delay -= 1
+                    continue
+                }
+                this.queue.splice(i, 1)
+                i--
+                this.executeAction(action)
+            }
+        }, 1000)
     },
 }
 
@@ -129,11 +194,13 @@ import FormFitter from './../vue/components/FormFitter.vue'
 import FormSection from "../vue/trash/v2/FormSection.vue"
 import FormTabs from "../vue/components/FormTabs.vue"
 import ClickOutside from '../vue/directives/ClickOutside'
+import autoRegisterMixin from './auto-register-mixin'
 
 const app = createApp(Threes)
 app.use(router);
 app.use(PrimeVue, {ripple: true})
 app.use(vueClickOutsideElement)
+app.mixin(autoRegisterMixin)
 app.component('FormFitter', FormFitter)
 app.component('FormSection', FormSection)
 app.component('FormTabs', FormTabs)

--- a/app/plugins/zen/threes/src/vue/components/FormInputSelect.vue
+++ b/app/plugins/zen/threes/src/vue/components/FormInputSelect.vue
@@ -83,11 +83,13 @@ export default {
             }, 300)
         },
         fetchOptions(query) {
-            ths.api({
-                api: '/api/' + this.search,
-                data: {
-                    search_text: query
-                },
+            ths.enqueue({
+                exec: () => ths.api({
+                    api: '/api/' + this.search,
+                    data: {
+                        search_text: query
+                    }
+                }),
                 then: options => {
                     this.preloader = false
                     this.loadedOptions = options || []

--- a/app/plugins/zen/threes/src/vue/components/Schema.vue
+++ b/app/plugins/zen/threes/src/vue/components/Schema.vue
@@ -144,11 +144,13 @@ export default {
     },
     methods: {
         getSchema() {
-            this.ths.api({
-                api: 'ui:get-schema-nodes',
-                data: {
-                    nid: this.nid
-                },
+            this.ths.enqueue({
+                exec: () => this.ths.api({
+                    api: 'ui:get-schema-nodes',
+                    data: {
+                        nid: this.nid
+                    }
+                }),
                 then: response => {
                     this.schema = response.schema
                 }
@@ -158,12 +160,14 @@ export default {
             if (!this.nid) {
                 return
             }
-            this.ths.api({
-                api: 'nodes.node:set-node-name',
-                data: {
-                    nid: this.nid, name
-                },
-                then: response => {
+            this.ths.enqueue({
+                exec: () => this.ths.api({
+                    api: 'nodes.node:set-node-name',
+                    data: {
+                        nid: this.nid, name
+                    }
+                }),
+                then: () => {
                     this.ths.bus.emit('tree:refresh')
                 }
             })
@@ -172,13 +176,15 @@ export default {
             if (!this.nid) {
                 return
             }
-            this.ths.api({
-                api: 'nodes.node:set-node-description',
-                data: {
-                    nid: this.nid,
-                    description
-                },
-                then: response => {
+            this.ths.enqueue({
+                exec: () => this.ths.api({
+                    api: 'nodes.node:set-node-description',
+                    data: {
+                        nid: this.nid,
+                        description
+                    }
+                }),
+                then: () => {
                     this.ths.bus.emit('tree:refresh')
                 }
             })
@@ -189,13 +195,15 @@ export default {
         },
         setNodeSettings()
         {
-            ths.api({
-                api: 'nodes.node:set-node-settings',
-                data: {
-                    nid: this.nid,
-                    settings: this.schema.props
-                },
-                then: response => {
+            ths.enqueue({
+                exec: () => ths.api({
+                    api: 'nodes.node:set-node-settings',
+                    data: {
+                        nid: this.nid,
+                        settings: this.schema.props
+                    }
+                }),
+                then: () => {
                     this.settings = null
                     this.getSchema()
                     this.ths.bus.emit('tree:refresh')
@@ -211,13 +219,15 @@ export default {
             if (!file) return
             const reader = new FileReader()
             reader.onload = () => {
-                ths.api({
-                    api: 'nodes.node:set-node-icon',
-                    data: {
-                        nid: this.nid,
-                        svg: reader.result
-                    },
-                    then: response => {
+                ths.enqueue({
+                    exec: () => ths.api({
+                        api: 'nodes.node:set-node-icon',
+                        data: {
+                            nid: this.nid,
+                            svg: reader.result
+                        }
+                    }),
+                    then: () => {
                         this.ths.bus.emit('tree:refresh')
                         this.ths.bus.emit('store:refresh')
                         this.getSchema()

--- a/app/plugins/zen/threes/src/vue/components/Store.vue
+++ b/app/plugins/zen/threes/src/vue/components/Store.vue
@@ -46,22 +46,26 @@ export default {
     },
     methods: {
         getStore() {
-            this.ths.api({
-                api: 'store:get',
+            this.ths.enqueue({
+                exec: () => this.ths.api({
+                    api: 'store:get'
+                }),
                 then: response => {
                     this.nodes = response.nodes
                 }
             })
         },
         addNode(node) {
-            ths.api({
-                api: 'nodes.node:add-node',
-                data: {
-                    nid: node.nid,
-                    class: node.class,
-                    after: ths.data.selected_nid,
-                },
-                then: response => {
+            ths.enqueue({
+                exec: () => ths.api({
+                    api: 'nodes.node:add-node',
+                    data: {
+                        nid: node.nid,
+                        class: node.class,
+                        after: ths.data.selected_nid,
+                    }
+                }),
+                then: () => {
                     ths.bus.emit('tree:refresh')
                 }
             })

--- a/app/plugins/zen/threes/src/vue/components/Tree.vue
+++ b/app/plugins/zen/threes/src/vue/components/Tree.vue
@@ -64,9 +64,11 @@ export default {
     },
     methods: {
         getTree() {
-            this.ths.api({
-                api: 'ui:get-tree-nodes',
-                data: { search: this.search },
+            this.ths.enqueue({
+                exec: () => this.ths.api({
+                    api: 'ui:get-tree-nodes',
+                    data: { search: this.search }
+                }),
                 then: response => {
                     this.tree = response.tree
                 }
@@ -77,13 +79,15 @@ export default {
             this.getTree()
         },
         moveAction({nid, direction}) {
-            this.ths.api({
-                api: 'nodes.node:move-node',
-                data: {
-                    nid: this.ths.data.node_actions_nid,
-                    target_nid: nid,
-                    direction: direction
-                },
+            this.ths.enqueue({
+                exec: () => this.ths.api({
+                    api: 'nodes.node:move-node',
+                    data: {
+                        nid: this.ths.data.node_actions_nid,
+                        target_nid: nid,
+                        direction: direction
+                    }
+                }),
                 then: () => {
                     this.ths.data.node_actions_nid = null
                     this.ths.data.node_action = null

--- a/app/plugins/zen/threes/src/vue/components/TreeItem.vue
+++ b/app/plugins/zen/threes/src/vue/components/TreeItem.vue
@@ -122,12 +122,14 @@ export default {
                 ths.data.node_action = action
             }
             if (action === 'delete') {
-                ths.api({
-                    api: 'nodes.node:delete-node',
-                    data: {
-                        nid: this.node.nid
-                    },
-                    then: response => {
+                ths.enqueue({
+                    exec: () => ths.api({
+                        api: 'nodes.node:delete-node',
+                        data: {
+                            nid: this.node.nid
+                        }
+                    }),
+                    then: () => {
                         console.log('Нод удалён')
                     }
                 })

--- a/app/plugins/zen/threes/src/vue/components/nodes/NodeBuilder.vue
+++ b/app/plugins/zen/threes/src/vue/components/nodes/NodeBuilder.vue
@@ -95,16 +95,15 @@ export default {
     methods: {
         saveContent() {
             const html = this.editor.getHtml()
-            ths.api({
-                api: 'nodes.node:update-data',
-                data: {
-                    nid: this.node.nid,
-                    data: html,
-                    scope: this.scope,
-                },
-                then: () => {
-
-                }
+            ths.enqueue({
+                exec: () => ths.api({
+                    api: 'nodes.node:update-data',
+                    data: {
+                        nid: this.node.nid,
+                        data: html,
+                        scope: this.scope,
+                    }
+                })
             });
         }
     },

--- a/app/plugins/zen/threes/src/vue/components/nodes/NodeText.vue
+++ b/app/plugins/zen/threes/src/vue/components/nodes/NodeText.vue
@@ -62,12 +62,14 @@ export default {
             }
         },
         updateData(data) {
-            this.ths.api({
-                api: 'nodes.node:update-data',
-                data: {
-                    nid: this.node.nid,
-                    data
-                },
+            this.ths.enqueue({
+                exec: () => this.ths.api({
+                    api: 'nodes.node:update-data',
+                    data: {
+                        nid: this.node.nid,
+                        data
+                    }
+                }),
                 then: () => {
                     this.ths.bus.emit('schema:refresh')
                 }

--- a/app/plugins/zen/threes/src/vue/trash/nodes/ButtonNode.vue
+++ b/app/plugins/zen/threes/src/vue/trash/nodes/ButtonNode.vue
@@ -7,10 +7,12 @@ export default {
     props: ['node'],
     methods: {
         executeNode() {
-            ths.api({
-                api: 'nodes.Node:Execute',
-                data: { nid: this.node.nid },
-                then: response => console.log(response),
+            ths.enqueue({
+                exec: () => ths.api({
+                    api: 'nodes.Node:Execute',
+                    data: { nid: this.node.nid }
+                }),
+                then: response => console.log(response)
             });
         },
     },

--- a/app/plugins/zen/threes/src/vue/trash/ux/elements/FrameVersion.vue
+++ b/app/plugins/zen/threes/src/vue/trash/ux/elements/FrameVersion.vue
@@ -33,11 +33,13 @@ export default {
     },
     methods: {
         getVersions() {
-            ths.api({
-                api: 'frames.Frame:getVersions',
-                data: {
-                    fid: this.fid
-                },
+            ths.enqueue({
+                exec: () => ths.api({
+                    api: 'frames.Frame:getVersions',
+                    data: {
+                        fid: this.fid
+                    }
+                }),
                 then: response => {
                     this.version = response.version
                     this.versions = response.versions
@@ -45,24 +47,28 @@ export default {
             })
         },
         restoreVersion() {
-            ths.api({
-                api: 'frames.Frame:restoreVersion',
-                data: {
-                    version_id: this.version
-                },
-                then: response => {
+            ths.enqueue({
+                exec: () => ths.api({
+                    api: 'frames.Frame:restoreVersion',
+                    data: {
+                        version_id: this.version
+                    }
+                }),
+                then: () => {
                     this.getVersions()
                     this.$emit('update:version')
                 }
             })
         },
         build() {
-            ths.api({
-                api: 'frames.Frame:buildFrame',
-                data: {
-                    fid: this.fid
-                },
-                then: response => {
+            ths.enqueue({
+                exec: () => ths.api({
+                    api: 'frames.Frame:buildFrame',
+                    data: {
+                        fid: this.fid
+                    }
+                }),
+                then: () => {
                     this.getVersions()
                     this.$emit('update:version')
                 }

--- a/app/plugins/zen/threes/src/vue/trash/ux/elements/NodePanel.vue
+++ b/app/plugins/zen/threes/src/vue/trash/ux/elements/NodePanel.vue
@@ -127,24 +127,28 @@ export default {
                 return;
             }
             let node = this.updated_node
-            ths.api({
-                api: 'nodes.Node:update',
-                data: {
-                    fid: this.fid,
-                    node
-                },
+            ths.enqueue({
+                exec: () => ths.api({
+                    api: 'nodes.Node:update',
+                    data: {
+                        fid: this.fid,
+                        node
+                    }
+                }),
                 then: response => {
                     this.$emit("update", response.node)
-                },
+                }
             })
         },
         reloadNode() {
-            ths.api({
-                api: 'nodes.Node:getNodeDsl',
-                data: {
-                    fid: this.fid,
-                    nid: this.node.nid
-                },
+            ths.enqueue({
+                exec: () => ths.api({
+                    api: 'nodes.Node:getNodeDsl',
+                    data: {
+                        fid: this.fid,
+                        nid: this.node.nid
+                    }
+                }),
                 then: response => {
                     this.$emit("update", response.node)
                 }

--- a/app/plugins/zen/threes/src/vue/trash/ux/elements/Store.vue
+++ b/app/plugins/zen/threes/src/vue/trash/ux/elements/Store.vue
@@ -87,11 +87,13 @@ export default {
             if (typeof filter_text === 'undefined') {
                 return
             }
-            ths.api({
-                api: 'layers.Layer:getStore',
-                data: {
-                    filter_text
-                },
+            ths.enqueue({
+                exec: () => ths.api({
+                    api: 'layers.Layer:getStore',
+                    data: {
+                        filter_text
+                    }
+                }),
                 then: response => {
                     this.layers = response.layers
                     this.unit_layers = response.unit_layers

--- a/app/plugins/zen/threes/src/vue/trash/v2/Frame.vue
+++ b/app/plugins/zen/threes/src/vue/trash/v2/Frame.vue
@@ -167,42 +167,48 @@ export default {
 
         // Добавить новую линию нодов
         addLine() {
-            ths.api({
-                api: 'nodes.node:add-line',
-                data: {
-                    nid: this.nid
-                },
-                then: response => {
+            ths.enqueue({
+                exec: () => ths.api({
+                    api: 'nodes.node:add-line',
+                    data: {
+                        nid: this.nid
+                    }
+                }),
+                then: () => {
                     this.getNodes();
-                },
+                }
             });
         },
 
         // Запрос нодов с сервера
         getNodes() {
-            ths.api({
-                api: 'nodes.node:get-nodes',
-                data: {
-                    nid: this.nid
-                },
+            ths.enqueue({
+                exec: () => ths.api({
+                    api: 'nodes.node:get-nodes',
+                    data: {
+                        nid: this.nid
+                    }
+                }),
                 then: response => {
                     this.nodes = response.nodes;
-                },
+                }
             });
         },
 
         // Сохранить текущее расположение нодов
         setNodes() {
             this.selected_nodes = [];
-            ths.api({
-                api: 'nodes.node:set-nodes',
-                data: {
-                    nid: this.nid,
-                    nodes: this.nodes
-                },
+            ths.enqueue({
+                exec: () => ths.api({
+                    api: 'nodes.node:set-nodes',
+                    data: {
+                        nid: this.nid,
+                        nodes: this.nodes
+                    }
+                }),
                 then: () => {
                     this.getNodes();
-                },
+                }
             });
         },
     },

--- a/app/plugins/zen/threes/src/vue/trash/v2/NodesMethods.vue
+++ b/app/plugins/zen/threes/src/vue/trash/v2/NodesMethods.vue
@@ -86,12 +86,14 @@ export default {
             if (this.selected_none) {
                 return
             }
-            ths.api({
-                api: 'nodes.Node:removeNodes',
-                data: {
-                    nid: this.nid,
-                    nids: this.nids
-                },
+            ths.enqueue({
+                exec: () => ths.api({
+                    api: 'nodes.Node:removeNodes',
+                    data: {
+                        nid: this.nid,
+                        nids: this.nids
+                    }
+                }),
                 then: () => {
                     this.$emit('update')
                 }
@@ -102,12 +104,14 @@ export default {
             if (this.selected_none) {
                 return
             }
-            ths.api({
-                api: 'nodes.Node:copyNodes',
-                data: {
-                    nid: this.nid,
-                    nids: this.nids
-                },
+            ths.enqueue({
+                exec: () => ths.api({
+                    api: 'nodes.Node:copyNodes',
+                    data: {
+                        nid: this.nid,
+                        nids: this.nids
+                    }
+                }),
                 then: () => {
                     this.$emit('update')
                 }

--- a/app/plugins/zen/threes/src/vue/trash/v2/NodesStore.vue
+++ b/app/plugins/zen/threes/src/vue/trash/v2/NodesStore.vue
@@ -45,25 +45,29 @@ export default {
             if (typeof filter_text === 'undefined') {
                 return
             }
-            ths.api({
-                api: 'nodes.store:get-store-nodes',
-                data: {
-                    filter_text: filter_text
-                },
+            ths.enqueue({
+                exec: () => ths.api({
+                    api: 'nodes.store:get-store-nodes',
+                    data: {
+                        filter_text: filter_text
+                    }
+                }),
                 then: response => {
                     this.store_nodes = response.store_nodes
                 }
             })
         },
         addNode(nid) {
-            ths.api({
-                api: 'nodes.node:add-node',
-                data: {
-                    nid,
-                    parent_nid: this.nid,
-                    line_index: this.line_index
-                },
-                then: response => {
+            ths.enqueue({
+                exec: () => ths.api({
+                    api: 'nodes.node:add-node',
+                    data: {
+                        nid,
+                        parent_nid: this.nid,
+                        line_index: this.line_index
+                    }
+                }),
+                then: () => {
                     this.$emit('update')
                 }
             })


### PR DESCRIPTION
## Summary
- add global action queue and dispatcher
- add auto-register mixin for Vue components
- wrap API calls through new queue mechanism
- fix queue hash generation and align style

## Testing
- `npm test` *(fails: Error: ENOENT: no such file or directory, open '/workspace/threes-project/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68417be445508322b2db695bb092f746