### PR TITLE
Fix Node runMethod security

### DIFF
--- a/app/plugins/zen/threes/api/nodes/Node.php
+++ b/app/plugins/zen/threes/api/nodes/Node.php
@@ -124,6 +124,13 @@ class Node extends ThreesApi
     {
         return $this->requireAuth(function () {
             $call = request('call');
+
+            $allowedPrefix = 'Zen.Threes.Classes.Methods.';
+            if (!is_string($call) || !str_starts_with($call, $allowedPrefix)) {
+                ths()->messages()->addMessage('Недопустимый вызов метода', 'error');
+                return ['success' => false];
+            }
+
             return ths()->exe($call);
         });
     }


### PR DESCRIPTION
## Summary
- restrict runMethod to internal Methods namespace to prevent arbitrary method execution

## Testing
- `php -v` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_686109e0f8948322ab003a3d32317999